### PR TITLE
fix title and navigation string still showing FUZZING'22 @ NDSS rather than FUZZING'23 @ ISSTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <meta name="resource-type" content="document">
     <meta name="distribution" content="global">
     <meta name="KeyWords" content="Fuzzing, preregistration, software testing, benchmarking">
-    <title>FUZZING'22 Workshop @ NDSS</title>
+    <title>FUZZING'23 Workshop @ ISSTA</title>
 </head>
 
 <body>
@@ -31,11 +31,11 @@
     <table class="navigation">
         <tr>
             <td class="navigation">
-                <a class="current" title="Fuzzing'22 Home Page" href="index.html">Home</a>
+                <a class="current" title="Fuzzing'23 Home Page" href="index.html">Home</a>
             </td>
             <!--
                  <td class="navigation">
-                 <a title="Register for Fuzzing'22" href="registration">Registration</a>
+                 <a title="Register for Fuzzing'23" href="registration">Registration</a>
                  </td>
             -->
             <!--


### PR DESCRIPTION
Hi,

when linking the website in our slack, I've noticed the title still shows as "FUZZING'22 @ NDSS" rather than "FUZZING'23 @ ISSTA" and updated index.html accordingly. This isn't much of an PR, feel free to reject & just address this yourself

Thanks a lot for organizing this workshop, looking forward to it!