### PR TITLE
FUZZING 2025 CFP and Committee Updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,26 +74,37 @@
         The <b>4th International Fuzzing Workshop (FUZZING) 2025</b> welcomes all researchers,
         scientists, engineers and practitioners to present their latest research findings,
         empirical analyses, techniques, and applications in the area of fuzzing and
-        software testing for automated bug finding.
+        software testing for automated bug finding. This year, the workshop will feature
+        multiple interleaved tracks.
     </p>
+    <h3>Main Track - Registered Reports for Research Papers</h3>
     <p>
-        The workshop will be organized as <b>Phase 1</b> in a <b>2-phase preregistration-based
+        This track will be organized as <b>Phase 1</b> in a <b>2-phase preregistration-based
         publication process</b>. All research papers will be peer-reviewed on the basis of a
         full-length preregistered report, and acceptance will be based on (i) the
         significance and novelty of the hypotheses or techniques, and (ii) the soundness
         and reproducibility of the methodology specified to validate the claims or
-        hypotheses -- but explicitly not based on the strength of the (preliminary)
-        results. The workshop solicits registered reports drafts. These drafts will be
-        reviewed by the workshop PC, and accepted drafts made available to all participants.
+        hypotheses -- but explicitly not based on the strength of the (preliminary) results.
+    </p>
+
+    <p>
+        In this track, the workshop solicits registered reports drafts.
+        Submitted report drafts are expected to be a full technical paper sans the
+        full evaluation/experiment results. To assess the feasibility of the experiments,
+        however, we expect some preliminary results in small-scale experiments.
+        These drafts will be reviewed by the workshop PC, and accepted drafts
+        will be made available to all participants.
         These drafts will be presented and discussed in detail at the workshop, in order
-        for the authors to receive constructive feedback.
+        for the authors to receive constructive feedback. For the final journal article,
+        the authors are expected to conduct the experiments, evaluation, or study as
+        specified in their registered report.
     </p>
     <p>
-        All papers accepted at the workshop will be invited as Phase 1
+        All papers accepted in this track will be invited as Phase 1
         <a href="https://dl.acm.org/journal/tosem/registered-papers">ACM TOSEM Registered Papers</a>
         where we will maintain an overlapping set of reviewers. After the workshop, in
         <b>Phase 2</b> of the publication process, the authors will conduct their full
-        experiments and submit their extended and updated papers. The reviewing in Phase 2,
+        experiments and submit their extended and updated papers. The reviewing in Phase 2
         will be also accompanied by an <b>artifact evaluation</b>. More details about the
         benefits of this process can be found in this blog post co-authored by the workshop
         organizers:
@@ -101,6 +112,31 @@
             http://fuzzbench.com/blog/2021/04/22/special-issue/
         </a>
     </p>
+    <p>
+        Depending on the authors' preference, accepted registered report drafts will be
+        published in the workshop proceedings of ISSTA'25.
+    </p>
+
+
+    <h3><em>Fuzzing Nuggets</em> - Short Papers Track</h3>
+
+    <p>
+        The workshop also solicits self-contained short papers of not more than 4 pages,
+        excluding references. This track is intended for evidence-backed position papers
+        on fuzzing research, or experience reports on state-of-the-art fuzzing practices.
+        The goal of this track is to serve as a platform for researchers and practitioners
+        to share substantiated opinions or reflections that would be of interest to the
+        larger fuzzing community, but which would not ordinarily be appropriate for a
+        full-length research paper. Papers will be evaluated by the workshop PC for
+        novelty, significance, and soundness of insights as well as clarity of presentation.
+        This track is NOT intended for publishing new research ideas that haven't been
+        fully empirically evaluated; the registered reports already serve that purpose.
+    </p>
+    <p>
+        All papers accepted to the short papers track will be published in the workshop
+        proceedings, and authors will be invited to give a lightning talk at the workshop.
+    </p>
+
     
     <!-- <h2 id="program">Program</h2>
 	<p>
@@ -135,46 +171,32 @@
 
     <h2 id="guides">Submission Guidelines</h2>
     <p>
-        TBA
-    </p>
-    <!-- <p>
-        The workshop solicits registered reports drafts. A registered report is a full 
-        paper sans the evaluation or experiments. Each draft will be reviewed by at least 
-        three members of the program committee according to the review criteria mentioned
-        above with the key objective of providing constructive feedback. Accepted drafts
-        are made available to all participants. These drafts will be presented and 
-        discussed in detail at the workshop in order for the authors to receive further
-        constructive feedback. For the final journal article,
-        the authors are expected to conduct the experiments, evaluation, or study as 
-        specified in their registered report. FUZZING'24 will employ a <b style="color:black;">double-anonymous policy</b> for all 
+        FUZZING'25 will employ a <b style="color:black;">double-anonymous policy</b> for all 
         submissions. Please ensure that the authors remain anonymous in your submission.
         For more details on this policy, please email us or consult this excellent
         <a href="https://pldi20.sigplan.org/track/pldi-2020-papers#FAQ-on-Double-Blind-Reviewing">FAQ</a>.
     </p>
     <p>
-        Submitted report drafts are expected to be a full technical paper sans the full 
-        evaluation/experiment results. To assess the feasibility of the experiments, 
-        however, we expect some preliminary results in small-scale experiments. 
-    </p>
-    <p>
-        Submitted report drafts should include no more than 8 pages, excluding references.
-        There are no page limits on the references. Papers must be formatted according to
-        the <a href="https://2024.issta.org/track/issta-2024-papers#submission-guidelines">ISSTA submission requirements</a>. Templates are available at 
+        Papers must be formatted according to
+        the <a href="https://conf.researchr.org/track/issta-2025/issta-2025-papers#submission-guidelines">ISSTA submission requirements</a>.
+        Templates are available at
         <a href="https://www.acm.org/publications/proceedings-template">ACM guidelines and templates</a>.
     </p>
     <p>
-        Depending on the authors' preference, accepted registered report drafts will be 
-        published in the workshop proceedings of ISSTA'25.
-    </p>
-    <p> -->
-        
+        Registered report drafts should include no more than 8 pages, excluding references.
+        Fuzzing nuggets should include no more than 4 pages, excluding references.
+        There are no page limits on the references.
     </p>
 
-    <!-- <h2>Submission</h2>
-    <p>Registered Report drafts can be submitted at:
-    <a href="https://fuzzing24.hotcrp.com">https://fuzzing24.hotcrp.com</a>. -->
-    
+    <h2>Submission</h2>
+
     <p>
+        Registered Report drafts can be submitted at:
+        <a href="https://fuzzing25.hotcrp.com">https://fuzzing25.hotcrp.com</a>.
+        Paper titles must end with either "(Registered Report)" or "(Short Paper)"
+        based on the track they are submitting to.
+    </p>
+
     <h2 id="faq">Preregistration FAQ</h2>
     <p><b>Q: Accepting papes without considering the outcome of the experiments
         sounds like "lowering the bar" for publication. Won't this lead to 
@@ -260,6 +282,8 @@
         <li>Marcel B&ouml;hme (MPI-SP and Monash University)</li>
         <li>Yannic Noller (Ruhr University Bochum)</li>
         <li>L&aacute;szl&oacute; Szekeres (Google)</li>
+        <li>Ruijie Meng (National University of Singapore)</li>
+        <li>Rohan Padhye (Carnegie Mellon University)</li>
     </ul>
     </p>
 


### PR DESCRIPTION
- Added info about short papers track
- Reorganized text about registered reports to untangle the two different tracks
- Revised and enabled submission guidelines
- Updated committee list to include Rohan and Ruijie